### PR TITLE
Fix persisting game data to local storage

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -29,6 +29,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
             'phone_number' => '+251912345678',
+            'phone_verified_at' => now()
         ]);
 
         $user->player()->create([
@@ -39,6 +40,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User 2',
             'email' => 'test2@example.com',
             'phone_number' => '+251911223344',
+            'phone_verified_at' => now()
         ]);
 
         $user->player()->create([

--- a/resources/js/Stores/useGameDataStore.ts
+++ b/resources/js/Stores/useGameDataStore.ts
@@ -5,7 +5,7 @@ import {RemovableRef, useStorage} from "@vueuse/core";
 interface GameStore {
     clickedNumbers: Array<(number|string)>;
     recentNumbers: Array<number>;
-    drawNumbers: Array<number>;
+    drawNumbers: Array<(number|string)>;
     revealIndex: number;
 }
 
@@ -14,14 +14,14 @@ export const useGameDataStore = defineStore('gameDataStore', () => {
     const persistedGameData: RemovableRef<GameStore> = useStorage('gameData', {
         clickedNumbers: ['FREE'],
         recentNumbers: [],
-        drawNumbers: [],
+        drawNumbers: ['FREE'],
         revealIndex: 0,
     })
 
 
     const clickedNumbers: Ref<Set<(number|string)>> = ref(new Set(persistedGameData.value.clickedNumbers));
     const recentNumbers: Ref<Array<number>> = ref(persistedGameData.value.recentNumbers);
-    const drawNumbers: Ref<Set<number>> = ref(new Set(persistedGameData.value.drawNumbers))
+    const drawNumbers: Ref<Set<(number|string)>> = ref(new Set(persistedGameData.value.drawNumbers))
     const revealIndex: Ref<number> = ref(persistedGameData.value.revealIndex);
 
     function addToDrawNumbers(numbers: Array<number>) {
@@ -34,6 +34,16 @@ export const useGameDataStore = defineStore('gameDataStore', () => {
     function addToClickedNumbers(number: number) {
         clickedNumbers.value.add(number)
         persistedGameData.value.clickedNumbers = Array.from(clickedNumbers.value)
+    }
+
+    function addToRecentNumbers(number: number) {
+        recentNumbers.value.unshift(number)
+
+        if (recentNumbers.value.length > 8) {
+            recentNumbers.value.pop()
+        }
+
+        persistedGameData.value.recentNumbers = recentNumbers.value
     }
 
     function setRecentNumbers(numbers: Array<number>) {
@@ -56,7 +66,7 @@ export const useGameDataStore = defineStore('gameDataStore', () => {
         recentNumbers.value = []
         revealIndex.value = 0
         drawNumbers.value = new Set([])
-        persistedGameData.value.drawNumbers = []
+        persistedGameData.value.drawNumbers = ['FREE']
         persistedGameData.value.clickedNumbers = ['FREE']
         persistedGameData.value.recentNumbers = []
         persistedGameData.value.revealIndex = 0
@@ -68,6 +78,7 @@ export const useGameDataStore = defineStore('gameDataStore', () => {
         setRecentNumbers,
         incrementRevealIndex,
         addToDrawNumbers,
+        addToRecentNumbers,
         resetRevealIndex,
         drawNumbers,
         clickedNumbers,


### PR DESCRIPTION
- Reimplement `fetchGameUpdates` call and `revealNumbers`
- Redefine how `recentNumbers` are popped and unshifted inside `useGameDataStore` pinia store
- DX: Seeder user data have `phone_verified_at` set to current time